### PR TITLE
Fix errors appears when email address passed as a username

### DIFF
--- a/cve_2020_10977.py
+++ b/cve_2020_10977.py
@@ -22,7 +22,7 @@ else:
 if base_url.endswith('/'):
 	base_url = base_url[:-1]
 
-username = args.username
+username = args.username.split('@')[0]
 password = args.password
 
 login_url = base_url + '/users/sign_in'


### PR DESCRIPTION
Closes issues: #1 and #2.

The error appears when a user passes email as a username (`john@my.gitlab.com` instead of `john`). Then the script tries to make requests to something like `https://my.gitlab.com/john@my.gitlab.com/issues/new` and fails.